### PR TITLE
Album Song Credits code making tons of API requests

### DIFF
--- a/Services/genius_album.js
+++ b/Services/genius_album.js
@@ -1,3 +1,5 @@
+const DELAY_BEFORE_CLEANUP = 250; // ? milliseconds
+
 chrome.storage.local.get([
     'Services/genius_album.js',
     'isGeniusAlbumAlbumPage',
@@ -198,26 +200,12 @@ chrome.storage.local.get([
             }*/
 
             async function songDataFunctions() {
-                const songsPerBatch = 25;
-                const delay = 750;
-                const songDataAlbum = [];
+                // ? Every function below needs the full song payload, which the API only serves one song at a time.
+                // * So don't spend a request per track when none of them are switched on.
+                if (!isGeniusAlbumFollowButton && !isGeniusAlbumCleanupButton && !isGeniusAlbumAlbumPageLyrics) return;
 
-                for (let i = 0; i < songIds.length; i += songsPerBatch) {
-                    const batch = songIds.slice(i, i + songsPerBatch);
-
-                    const batchResults = await Promise.all(
-                        batch.map(async songId => {
-                            const { song: songData } = await getApiData(songId, "songs");
-                            return songData;
-                        })
-                    );
-
-                    songDataAlbum.push(...batchResults);
-
-                    if (i + songsPerBatch < songIds.length) {
-                        await new Promise(resolve => setTimeout(resolve, delay));
-                    }
-                }
+                // * getApiDataBatch() queues through the shared rate limiter, so this stays under the API budget.
+                const songDataAlbum = (await getApiDataBatch(songIds, "songs")).map(data => data?.song).filter(Boolean);
 
                 if (!songDataAlbum.length) return;
 
@@ -287,8 +275,9 @@ chrome.storage.local.get([
             while ((match = songIdRegex.exec(html)) !== null) {
                 songIds.push(match[1]);
             }
+            // * geniusFetch() queues through the shared rate limiter, so long tracklists don't fire at once.
             const responses = await Promise.all(songIds.map(songId =>
-                fetch(`https://genius.com/api/songs/${songId}`).then(res => res.json())
+                geniusFetch(`https://genius.com/api/songs/${songId}`).then(res => res.json())
             ));
             return responses;
         }
@@ -1184,7 +1173,7 @@ chrome.storage.local.get([
             buttons[buttons.length - 1].style.display = "none";
         }
 
-        const response = await fetch(`https://genius.com/api/albums/${albumId}`);
+        const response = await geniusFetch(`https://genius.com/api/albums/${albumId}`);
         const json = await response.json();
         const coverArts = json.response.album.cover_arts;
 
@@ -1634,7 +1623,7 @@ chrome.storage.local.get([
 
             const responses = await Promise.all(
                 songIds.map(songId =>
-                    fetch(`https://genius.com/api/songs/${songId}`)
+                    geniusFetch(`https://genius.com/api/songs/${songId}`)
                         .then(res => res.json())
                 )
             );
@@ -3990,6 +3979,7 @@ chrome.storage.local.get([
 
     function songCreditsButtonAlbumPage(songIds) {
         console.log("Run function songCreditsButtonAlbumPage()");
+        const DELAY_BEFORE_REOPEN = 150; // ? milliseconds
 
         const { stickyToolbarLeft, smallButton } = getDomElements();
         if (!stickyToolbarLeft || !smallButton) return;
@@ -4177,35 +4167,16 @@ chrome.storage.local.get([
                     })
                 );*/
 
-                async function fetchSongData(ids) {
-                    const songs = 25;
-                    const delay = 500;
-                    const results = [];
+                // * Queued through the shared rate limiter instead of firing every selected track at once.
+                const songDataAlbum = (await getApiDataBatch(allSongIds, "songs")).map(data => data?.song).filter(Boolean);
 
-                    for (let i = 0; i < ids.length; i += songs) {
-                        const batch = ids.slice(i, i + songs);
-
-                        const batchResults = await Promise.all(
-                            batch.map(async songId => {
-                                const { song: songData } = await getApiData(songId, "songs");
-                                return songData;
-                            })
-                        );
-
-                        results.push(...batchResults);
-
-                        if (i + songs < ids.length) {
-                            await new Promise(resolve => setTimeout(resolve, delay));
-                        }
-                    }
-
-                    return results;
+                // ! Payloads are merged into the song's current data, so a missing song could wipe its metadata. Save nothing instead.
+                if (songDataAlbum.length !== allSongIds.length) {
+                    modal.status.textContent = `Could not load ${allSongIds.length - songDataAlbum.length} of ${allSongIds.length} selected songs. Nothing was saved, please try again.`;
+                    return;
                 }
 
-                const songDataAlbum = await fetchSongData(allSongIds);
-
-
-                if (!songDataAlbum) return;
+                if (!songDataAlbum.length) return;
 
                 const primaryArtistsPayload = creditsState.primaryArtistsArray.map(primary_artists => ({ id: primary_artists.id, name: primary_artists.name }));
                 const featuredArtistsPayload = creditsState.featuredArtistsArray.map(featured_artists => ({ id: featured_artists.id, name: featured_artists.name }));
@@ -4814,15 +4785,16 @@ chrome.storage.local.get([
 
                 await runInParallel();
 
-                modal.status.textContent = "Done!";
+                modal.status.textContent = autoReopenSongCredits ? "Done! Reopening editor..." : "Done!";
 
-                setTimeout(() => {
+                setTimeout(async () => {
+                    modal.stopObservers();
                     document.body.removeChild(modal.overlay);
                     document.body.style.overflow = "";
                     setTimeout(() => {
                         if (autoReopenSongCredits) openCreditsEditor();
-                    }, 150);
-                }, 250);
+                    }, DELAY_BEFORE_REOPEN);
+                }, DELAY_BEFORE_CLEANUP);
 
             });
         }

--- a/Services/genius_artist.js
+++ b/Services/genius_artist.js
@@ -107,7 +107,7 @@ chrome.storage.local.get([
         if (!artistId || !userId) return { artistId: null, userId, artistData: null };
 
         // Artist Data
-        const response = await fetch(`https://genius.com/api/artists/${artistId}`);
+        const response = await geniusFetch(`https://genius.com/api/artists/${artistId}`);
         const json = await response.json();
 
         return { artistId, userId, artistData: json.response.artist };
@@ -342,14 +342,14 @@ chrome.storage.local.get([
             const blackSquare = document.createElement('span');
             blackSquare.className = 'black-square';
             blackSquare.style.cssText = `
-            height: 8px; 
-            width: 8px; 
-            background-color: #2C2C2C; 
-            display: inline-block; 
-            position: absolute; 
+            height: 8px;
+            width: 8px;
+            background-color: #2C2C2C;
+            display: inline-block;
+            position: absolute;
             top: 50%;
             left: 50%;
-            transform: translate(-50%, -50%); 
+            transform: translate(-50%, -50%);
         `;
             square.appendChild(blackSquare);
         }
@@ -364,14 +364,14 @@ chrome.storage.local.get([
             const square = document.createElement('span');
             square.className = 'square-indicator';
             square.style.cssText = `
-                font-variant: JIS04; 
-                height: 16px; 
-                width: 28px; 
-                display: inline-block; 
-                margin-left: -0.100rem; 
-                margin-right: 0.375rem; 
+                font-variant: JIS04;
+                height: 16px;
+                width: 28px;
+                display: inline-block;
+                margin-left: -0.100rem;
+                margin-right: 0.375rem;
                 position: relative;
-                background-color: ${color}; 
+                background-color: ${color};
                 border: 1px solid ${borderColor};
             `;
             button.style.cssText += `
@@ -653,7 +653,7 @@ chrome.storage.local.get([
     async function fetchAllSongIds(artistId) {
         let songIds = [], page = 1, perPage = 50;
         while (true) {
-            const json = await fetch(`https://genius.com/api/artists/${artistId}/songs?page=${page}&per_page=${perPage}`)
+            const json = await geniusFetch(`https://genius.com/api/artists/${artistId}/songs?page=${page}&per_page=${perPage}`)
                 .then(res => res.json());
             if (!json.response.songs?.length) break;
 
@@ -828,7 +828,7 @@ chrome.storage.local.get([
         }
 
         async function fetchSongDetails(songId) {
-            const res = await fetch(`https://genius.com/api/songs/${songId}`);
+            const res = await geniusFetch(`https://genius.com/api/songs/${songId}`);
             if (!res.ok) throw new Error(`Song ${songId}: ${res.status}`);
             return res.json();
         }
@@ -1255,13 +1255,13 @@ chrome.storage.local.get([
         }
 
         async function fetchSongDetails(songId) {
-            const res = await fetch(`https://genius.com/api/songs/${songId}`);
+            const res = await geniusFetch(`https://genius.com/api/songs/${songId}`);
             if (!res.ok) throw new Error(`Song ${songId}: ${res.status}`);
             return res.json();
         }
 
         async function fetchAlbumDetails(albumId) {
-            const res = await fetch(`https://genius.com/api/albums/${albumId}`);
+            const res = await geniusFetch(`https://genius.com/api/albums/${albumId}`);
             if (!res.ok) throw new Error(`Album ${albumId}: ${res.status}`);
             return res.json();
         }
@@ -1990,7 +1990,7 @@ chrome.storage.local.get([
 
                 const chunkResults = await Promise.all(
                     chunk.map(song =>
-                        fetch(`https://genius.com/api/songs/${song.id}`)
+                        geniusFetch(`https://genius.com/api/songs/${song.id}`)
                             .then(res => res.json())
                             .then(json => {
                                 const songData = json.response.song;

--- a/Services/genius_utils.js
+++ b/Services/genius_utils.js
@@ -94,8 +94,10 @@ const rateLimitGeniusRequest = (function createGeniusRateLimiter(maxPerSecond) {
         }
 
         if (queue.length && !pumpScheduled) {
-            const oldestStart = starts[0] ?? Date.now();
-            schedulePump(Math.max(windowMs - (Date.now() - oldestStart), 10));
+            const oldestStart = starts[0] ?? Date.now();
+
+            schedulePump(Math.max(windowMs - (Date.now() - oldestStart), 10));
+
         }
     }
 
@@ -424,7 +426,7 @@ async function sendUpdateRequest(songId, payload) {
     }
 }
 
-async function fetchSuggestions(type, query) {
+    const response = await fetch(url, {
     const url = `https://genius.com/api/${type}/autocomplete?q=${encodeURIComponent(query)}&text_format=html,markdown`;
     const response = await geniusFetch(url, {
         method: 'GET',

--- a/Services/genius_utils.js
+++ b/Services/genius_utils.js
@@ -115,7 +115,9 @@ function geniusFetch(url, options) {
 async function getApiData(id, type) {
     return rateLimitGeniusRequest(async () => {
         const response = await fetch(`https://genius.com/api/${type}/${id}`);
+        if (!response.ok) throw new Error(`${type}/${id}: ${response.status} ${response.statusText}`);
         const json = await response.json();
+        if (!json?.response) throw new Error(`${type}/${id}: missing response payload`);
 
         return json.response;
     });

--- a/Services/genius_utils.js
+++ b/Services/genius_utils.js
@@ -66,16 +66,80 @@ function getCsrfToken() {
     return match ? decodeURIComponent(match[1]) : '';
 }
 
-async function getApiData(id, type) {
-    const response = await fetch(`https://genius.com/api/${type}/${id}`);
-    const json = await response.json();
+// ? Shared rate limiter for every Genius API call the extension can fan out over a tracklist.
+// * Album pages need one request per song, so an unthrottled fan-out gets users rate limited and hammers Genius.
+// * Requests queue here and start at most GENIUS_REQUESTS_PER_SECOND per rolling second, in the order they were queued.
+const GENIUS_REQUESTS_PER_SECOND = 10;
 
-    return json.response;
+const rateLimitGeniusRequest = (function createGeniusRateLimiter(maxPerSecond) {
+    const windowMs = 1000;
+    const starts = [];
+    const queue = [];
+    let pumpScheduled = false;
+
+    function schedulePump(waitMs) {
+        pumpScheduled = true;
+        setTimeout(pump, waitMs);
+    }
+
+    function pump() {
+        pumpScheduled = false;
+
+        const now = Date.now();
+        while (starts.length && now - starts[0] >= windowMs) starts.shift();
+
+        while (queue.length && starts.length < maxPerSecond) {
+            starts.push(Date.now());
+            queue.shift()();
+        }
+
+        if (queue.length && !pumpScheduled) {
+            schedulePump(Math.max(windowMs - (Date.now() - starts[0]), 10));
+        }
+    }
+
+    return function rateLimitGeniusRequest(task) {
+        return new Promise((resolve, reject) => {
+            // ! A failing task must settle its own promise only, never stall the queue.
+            queue.push(() => Promise.resolve().then(task).then(resolve, reject));
+            if (!pumpScheduled) schedulePump(0);
+        });
+    };
+})(GENIUS_REQUESTS_PER_SECOND);
+
+// ? Drop-in fetch for genius.com/api calls that charges the request against the shared budget above.
+function geniusFetch(url, options) {
+    return rateLimitGeniusRequest(() => fetch(url, options));
+}
+
+async function getApiData(id, type) {
+    return rateLimitGeniusRequest(async () => {
+        const response = await fetch(`https://genius.com/api/${type}/${id}`);
+        const json = await response.json();
+
+        return json.response;
+    });
+}
+
+// ? Loads many ids through the rate limiter and keeps the input order.
+// * A single failed request returns null instead of rejecting the whole batch, so one rate limited song can't blank the page.
+async function getApiDataBatch(ids, type) {
+    const results = await Promise.all(ids.map(id =>
+        getApiData(id, type).catch(error => {
+            console.warn(`Request for ${type}/${id} failed:`, error);
+            return null;
+        })
+    ));
+
+    const failed = results.filter(result => result === null).length;
+    if (failed) console.warn(`${failed} of ${ids.length} ${type} requests failed`);
+
+    return results;
 }
 
 async function followId(id, type, action) {
     const url = `https://genius.com/api/${type}/${id}/${action}`;
-    const response = await fetch(url, {
+    const response = await geniusFetch(url, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -95,7 +159,7 @@ async function followId(id, type, action) {
 async function updateSongMetadata(song, payload) {
     if (Object.keys(payload).length === 0) return;
     try {
-        const response = await fetch(`https://genius.com/api/songs/${song.id}`, {
+        const response = await geniusFetch(`https://genius.com/api/songs/${song.id}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -117,7 +181,7 @@ async function updateSongMetadata(song, payload) {
 async function updateAlbumMetadata(album, payload) {
     if (Object.keys(payload).length === 0) return;
     try {
-        const response = await fetch(`https://genius.com/api/albums/${album.id}`, {
+        const response = await geniusFetch(`https://genius.com/api/albums/${album.id}`, {
             method: "PUT",
             headers: {
                 "Content-Type": "application/json",
@@ -143,7 +207,7 @@ async function updateAlbumMetadata(album, payload) {
 async function updateSongLyrics(song, payload) {
     if (Object.keys(payload).length === 0) return;
     try {
-        const response = await fetch(`https://genius.com/api/songs/${song.id}/lyrics`, {
+        const response = await geniusFetch(`https://genius.com/api/songs/${song.id}/lyrics`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -171,7 +235,7 @@ async function updateSongMetadata2(song, updates) {
 
     try {
         if (needsTitleUpdate && isPublished) {
-            const unpublishResponse = await fetch(`https://genius.com/api/songs/${song.id}/unpublish`, {
+            const unpublishResponse = await geniusFetch(`https://genius.com/api/songs/${song.id}/unpublish`, {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json',
@@ -187,7 +251,7 @@ async function updateSongMetadata2(song, updates) {
             }
         }
 
-        const updateResponse = await fetch(`https://genius.com/api/songs/${song.id}`, {
+        const updateResponse = await geniusFetch(`https://genius.com/api/songs/${song.id}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -204,7 +268,7 @@ async function updateSongMetadata2(song, updates) {
         }
 
         if (needsTitleUpdate && isPublished) {
-            const publishResponse = await fetch(`https://genius.com/api/songs/${song.id}/publish`, {
+            const publishResponse = await geniusFetch(`https://genius.com/api/songs/${song.id}/publish`, {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json',
@@ -227,7 +291,7 @@ async function updateSongMetadata2(song, updates) {
 
 async function toggleFollowSong(songId, action) {
     const url = `https://genius.com/api/songs/${songId}/${action}`;
-    const response = await fetch(url, {
+    const response = await geniusFetch(url, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -249,7 +313,7 @@ async function sendCoverArts(imageUrl, albumId) {
     };
 
     try {
-        const response = await fetch("https://genius.com/api/cover_arts/", {
+        const response = await geniusFetch("https://genius.com/api/cover_arts/", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
@@ -274,7 +338,7 @@ async function sendCoverArts(imageUrl, albumId) {
 
 async function deleteCoverArts(coverId) {
     try {
-        const response = await fetch(`https://genius.com/api/cover_arts/${coverId}`, {
+        const response = await geniusFetch(`https://genius.com/api/cover_arts/${coverId}`, {
             method: "DELETE",
             headers: {
                 "Content-Type": "application/json",
@@ -313,7 +377,7 @@ async function moveCoverArts(position, coverId, coverArts) {
     }
 
     try {
-        const response = await fetch(`https://genius.com/api/cover_arts/${coverId}/move_between`, {
+        const response = await geniusFetch(`https://genius.com/api/cover_arts/${coverId}/move_between`, {
             method: "PUT",
             headers: {
                 "Content-Type": "application/json",
@@ -337,7 +401,7 @@ async function moveCoverArts(position, coverId, coverArts) {
 
 async function sendUpdateRequest(songId, payload) {
     const url = `https://genius.com/api/songs/${songId}`;
-    const response = await fetch(url, {
+    const response = await geniusFetch(url, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
@@ -357,7 +421,7 @@ async function sendUpdateRequest(songId, payload) {
 
 async function fetchSuggestions(type, query) {
     const url = `https://genius.com/api/${type}/autocomplete?q=${encodeURIComponent(query)}&text_format=html,markdown`;
-    const response = await fetch(url, {
+    const response = await geniusFetch(url, {
         method: 'GET',
         headers: {
             'Content-Type': 'application/json',

--- a/Services/genius_utils.js
+++ b/Services/genius_utils.js
@@ -94,7 +94,8 @@ const rateLimitGeniusRequest = (function createGeniusRateLimiter(maxPerSecond) {
         }
 
         if (queue.length && !pumpScheduled) {
-            schedulePump(Math.max(windowMs - (Date.now() - starts[0]), 10));
+            const oldestStart = starts[0] ?? Date.now();
+            schedulePump(Math.max(windowMs - (Date.now() - oldestStart), 10));
         }
     }
 
@@ -115,9 +116,11 @@ function geniusFetch(url, options) {
 async function getApiData(id, type) {
     return rateLimitGeniusRequest(async () => {
         const response = await fetch(`https://genius.com/api/${type}/${id}`);
-        if (!response.ok) throw new Error(`${type}/${id}: ${response.status} ${response.statusText}`);
+        if (!response.ok) throw new Error(`${type}/${id}: ${response.status} ${response.statusText}`);
+
         const json = await response.json();
-        if (!json?.response) throw new Error(`${type}/${id}: missing response payload`);
+        if (!json?.response) throw new Error(`${type}/${id}: missing response payload`);
+
 
         return json.response;
     });


### PR DESCRIPTION
# resolve after #74

## Why

Album pages need the full song payload for every track, and `api/songs/:id` only serves one song per
request. Firing them all at once got users rate limited by Genius and put unnecessary load on their
servers.

## How it works now

One shared sliding-window limiter in [Services/genius_utils.js](Services/genius_utils.js) paces every
Genius API call the extension makes. Requests queue and start in order, at most
`GENIUS_REQUESTS_PER_SECOND` (currently `10`) per rolling second — that constant is the only knob.

Reads and writes share the same budget, so a follow-all click, a credits save and a page load can't
stack up on top of each other.

- `getApiData(id, type)` — single record, paced.
- `getApiDataBatch(ids, type)` — many records, paced, input order kept. A failed request becomes `null` instead of rejecting the whole batch, so one rate limited song can't blank the page.
- `geniusFetch(url, options)` — drop-in `fetch` for any other `genius.com/api` call (follows, metadata writes, cover arts).

`fetchSuggestions()` is deliberately left unpaced so autocomplete stays responsive while typing.

## Fetching less in the first place

- The album page skips the per-song fan-out entirely when Follow Button, Cleanup Metadata and Lyric State are all switched off.
- The song credits editor only loads the tracks that are actually selected, and only when Save is clicked.
- If any selected song fails to load, the save aborts with a message instead of merging a payload into missing data.

## Why the requests can't just be read from the page

`window.__PRELOADED_STATE__` (40 fields per song) and `api/albums/:id/tracks` (32 fields) both use
Genius's slim song serialization. `api/songs/:id` returns 85 fields, and the features on the album page
depend on ones the slim shapes omit:

| Feature          | Needs                                                                             |
| ---------------- | --------------------------------------------------------------------------------- |
| Cleanup Metadata | `custom_performances`, `custom_song_art_image_url`, `albums`, `published`         |
| Lyric State      | `lyrics_marked_complete_by`, `lyrics_marked_staff_approved_by`, `lyrics_verified` |
| Follow Button    | `current_user_metadata.interactions.following`                                    |

These are missing from the slim payloads for logged-in editors too, so reading from the preloaded state
would silently degrade those indicators rather than save requests. Pacing the requests is the fix;
dropping them is not an option while these features exist.
