### PR TITLE
Replace '&' with 'and' in English cleanup

### DIFF
--- a/Services/genius_song.js
+++ b/Services/genius_song.js
@@ -2504,6 +2504,8 @@ chrome.storage.local.get([
                             line = line.replace(/'\bCuz\b/g, "'Cause");
                             line = line.replace(/'\bcuz\b/g, "'cause");
 
+                            line = line.replace(/ & /g, " and ");
+
                             const slangMap = {
                                 'ay': 'ayy',
                                 'aye': 'ayy',


### PR DESCRIPTION
Only when surrounded by spaces, to avoid screwing with HTML character escapes or brand names such as H&M or A&E